### PR TITLE
Pd 13.opt.in.and.streamline.options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    persisted_cache (0.1.1)
+    persisted_cache (0.1.2)
       rails (> 4.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DB layer for Rails.cache.fetch.
 
-Rails.cache.fetch(key){block} is pretty clean. On cache miss, the block is executed. Results are stored in the Rails.cache and returned. Subsequent calls are returned from the cache. Easy peasy. We use this for things like dashboard tiles which take some time to build and don't change very often. 
+Rails.cache.fetch(key){block} is pretty clean. On cache miss, the block is executed. Results are stored in the Rails cache and returned. Subsequent calls are returned from the cache. Easy peasy. We use this for things like dashboard tiles which take some time to build and don't change very often. 
 
 Recently we decided to lean on this technique a little harder. We build reports that can include a million rows. In order to display them quickly, we've always used summary tables. Easy enough, but we always seemed to be wanting another column that wasn't summarized.
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Recently we decided to lean on this technique a little harder. We build reports 
 
 After this happened a few times, we decided to ditch the summary table approach and just do long running queries at night against the models with all the detail. Instead of building a summarization model which can go out of date, we'd just store the data as a serialized hash every night. If we learned we needed another column, we could just start storing it. We wouldn't want to pull those hashes out of the db all the time though, so we would cache them. 
 
-It seemed natural to extend Rails.cache.fetch to persist and cache them at the same time. On cache miss, if an option of use_persisted: true is passed, **persisted_cache**  tries to fall back to a value in the db. If it's not there, the block is executed and the value is stored in the cache as usual.
+It seemed natural to extend Rails.cache.fetch to persist and cache them at the same time. On cache miss, if an option of **persisted_cache: 'read'** is passed to Rails.cache.fetch, **persisted_cache**  tries to fall back to a value in the db. If it's not there, the block is executed and the value is stored in the cache as usual.
 
-To prime the cache, **persist: true** is passed as an option to the fetch method. The block is executed and saved in the db and Rails cache.
+To prime the cache, **persisted_cache: 'write'** is passed as an option to the fetch method. The block is executed and saved in the db and Rails cache.
 
-We needed to handle the case when a new user was looking for reports before we generated them and they weren't cached yet.  Use the **fail_on_cache_miss** option for this.  It causes a PersistedCache::MissingRequiredCache exception to be raised if there is no value in the cache. (We rescue this in the controller to show u/i which says the report is being built.)
+We needed to handle the case when a new user was looking for reports before we generated them and they weren't cached yet.  Use the **persisted_cache: 'require'** option for this.  It causes a PersistedCache::MissingRequiredCache exception to be raised if there is no value in the cache. (We rescue this in the controller to show u/i which says the report is being built.)
 
-If there is reason to delete the key instead of just updating the value, a **delete_persisted** option can be passed to Rails.cache.delete which will delete the key value pair from the db when it is cleared from the cache.
+If there is reason to delete the key instead of just updating the value, a **persisted_cache: 'delete'** option can be passed to Rails.cache.delete which will delete the key value pair from the db when it is cleared from the cache.
 
 Finally this table could get large. We needed to be able to save these results in a different db. This is supported by allowing an alternate base class for the KeyValuePair model to be specified in **initializers/persisted_cache.rb**.
 
@@ -49,10 +49,10 @@ rake db:migrate
 In the console...
 
 
-By passing persist: true we write the value of the block to the key_value_pairs table.
+By passing **persisted_cache: 'write'** we write the value of the block to the key_value_pairs table.
 
 ~~~~
-2.1.8 :011 > Rails.cache.fetch('my_key', persist: true){[:foo, :bar, :baz]}
+2.1.8 :011 > Rails.cache.fetch('my_key', persisted_cache: 'write'){[:foo, :bar, :baz]}
 ...
   SQL (0.4ms)  INSERT INTO "key_value_pairs" ("key", "value", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["key", "my_key"], ["value", "---\n- :foo\n- :bar\n- :baz\n"], ["created_at", "2016-09-22 20:43:34.756302"], ["updated_at", "2016-09-22 20:43:34.756302"]]
    (0.7ms)  COMMIT  
@@ -62,7 +62,7 @@ By passing persist: true we write the value of the block to the key_value_pairs 
 Next time we call fetch it returns the value from the cache (notice no DB queries in the logs and value is not from the block.)
 
 ~~~~
-2.1.8 :012 > Rails.cache.fetch('my_key'){[:something, :else]}
+2.1.8 :012 > Rails.cache.fetch('my_key', persisted_cache: 'read'){[:something, :else]}
  => [:foo, :bar, :baz] 
 ~~~~
 
@@ -71,7 +71,7 @@ If we clear the cache, we see that the next call gets its result from the DB, no
 ~~~~
 2.1.8 :013 > Rails.cache.clear
  => "OK" 
-2.1.8 :014 > Rails.cache.fetch('my_key'){[:something, :else]}
+2.1.8 :014 > Rails.cache.fetch('my_key', persisted_cache: 'read'){[:something, :else]}
   PersistedCache::KeyValuePair Load (0.6ms)  SELECT  "key_value_pairs".* FROM "key_value_pairs" WHERE "key_value_pairs"."key" = $1  ORDER BY "key_value_pairs"."id" ASC LIMIT 1  [["key", "my_key"]]
  => [:foo, :bar, :baz] 
 ~~~~ 
@@ -80,7 +80,7 @@ It has now been set in the cache again, so subsequent calls do not hit the DB.
 
 ~~~~
 
- 2.1.8 :015 > Rails.cache.fetch('my_key'){[:something, :else]}
+ 2.1.8 :015 > Rails.cache.fetch('my_key', persisted_cache: 'read'){[:something, :else]}
  => [:foo, :bar, :baz] 
 ~~~~
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ It seemed natural to extend Rails.cache.fetch to persist and cache them at the s
 
 To prime the cache, **persist: true** is passed as an option to the fetch method. The block is executed and saved in the db and Rails cache.
 
-When we launched, we had to backfill old reports that users might never access. We didn't need them in Rails.cache, but they had to be in the db. For this case, pass **skip_rails_cache: true** and the key value pair will be stored in the db, but not the rails cache.
-
-We also needed to handle the case when a new user was looking for reports before we generated them and they weren't cached yet.  Use the **fail_on_cache_miss** option for this.  It causes a PersistedCache::MissingRequiredCache exception to be raised if there is no value in the cache. (We rescue this in the controller to show u/i which says the report is being built.)
+We needed to handle the case when a new user was looking for reports before we generated them and they weren't cached yet.  Use the **fail_on_cache_miss** option for this.  It causes a PersistedCache::MissingRequiredCache exception to be raised if there is no value in the cache. (We rescue this in the controller to show u/i which says the report is being built.)
 
 If there is reason to delete the key instead of just updating the value, a **delete_persisted** option can be passed to Rails.cache.delete which will delete the key value pair from the db when it is cleared from the cache.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Rails.cache.fetch(key){block} is pretty clean. On cache miss, the block is execu
 
 Recently we decided to lean on this technique a little harder. We build reports that can include a million rows. In order to display them quickly, we've always used summary tables. Easy enough, but we always seemed to be wanting another column that wasn't summarized.
 
-After this happened a few times, we decided to ditch the summary table approach and just do long running queries at night against the models with all the detail. Instead of building a model which can go out of date, we'd just store the data as a serialized hash every night. If we learned we needed another column, we could just start storing it. We wouldn't want to pull those hashes out of the db all the time though, so we would want to cache them. 
+After this happened a few times, we decided to ditch the summary table approach and just do long running queries at night against the models with all the detail. Instead of building a summarization model which can go out of date, we'd just store the data as a serialized hash every night. If we learned we needed another column, we could just start storing it. We wouldn't want to pull those hashes out of the db all the time though, so we would cache them. 
 
-It seemed natural to extend Rails.cache.fetch to persist and cache them at the same time. On cache miss, **persisted_cache**  tries to fall back to a value in the db. If it's not there, the block is executed and the value is stored in the cache as usual.
+It seemed natural to extend Rails.cache.fetch to persist and cache them at the same time. On cache miss, if an option of use_persisted: true is passed, **persisted_cache**  tries to fall back to a value in the db. If it's not there, the block is executed and the value is stored in the cache as usual.
 
 To prime the cache, **persist: true** is passed as an option to the fetch method. The block is executed and saved in the db and Rails cache.
 

--- a/lib/extension.rb
+++ b/lib/extension.rb
@@ -28,11 +28,7 @@ module PersistedCache
         value = yield
         PersistedCache::KeyValuePair.where(key: name).first.try(:destroy)
         PersistedCache::KeyValuePair.create!(key: name, value: value)
-        unless options[:skip_rails_cache]
-          Rails.cache.write(name, value, options)
-        else
-          Rails.cache.delete(name, options)
-        end
+        Rails.cache.delete(name, options)
         return value
       end
       if persisted_value = PersistedCache::KeyValuePair.where(key: name).first.try(:value)

--- a/lib/extension.rb
+++ b/lib/extension.rb
@@ -31,12 +31,14 @@ module PersistedCache
         Rails.cache.delete(name, options)
         return value
       end
-      if persisted_value = PersistedCache::KeyValuePair.where(key: name).first.try(:value)
-        Rails.cache.write(name, persisted_value, options)
-        return persisted_value
-      else
-        if options[:fail_on_cache_miss]
-          raise PersistedCache::MissingRequiredCache.new("Required cached object does not exist in cache.")
+      if options[:use_persisted]
+        if persisted_value = PersistedCache::KeyValuePair.where(key: name).first.try(:value)
+          Rails.cache.write(name, persisted_value, options)
+          return persisted_value
+        else
+          if options[:fail_on_cache_miss]
+            raise PersistedCache::MissingRequiredCache.new("Required cached object does not exist in cache.")
+          end
         end
       end
       super

--- a/lib/extension.rb
+++ b/lib/extension.rb
@@ -3,10 +3,7 @@ module PersistedCache
 
     def fetch(name, options = nil)
       options = merged_options(options)
-      if options && options[:persist]
-        if options[:fail_on_cache_miss]
-          raise PersistedCache::InvalidOptions.new("Cannot persist if fail_on_cache_miss is true.")
-        end
+      if options && options[:persisted_cache] == 'write'
         options.merge!(force: true)
       end
       super
@@ -14,9 +11,14 @@ module PersistedCache
 
     def read(name, options = nil)
       unless result = super
+        return unless options && %w{read require}.include?(options[:persisted_cache])
         if persisted_value = PersistedCache::KeyValuePair.where(key: name).first.try(:value)
           Rails.cache.write(name, persisted_value, options)
           result = persisted_value
+        else
+          if options[:persisted_cache] == 'require'
+            raise PersistedCache::MissingRequiredCache.new("Required cached object does not exist in cache.")
+          end
         end
       end
       result
@@ -24,19 +26,19 @@ module PersistedCache
 
     def save_block_result_to_cache(name, options)
       options = merged_options(options)
-      if options && options[:persist]
+      if options && options[:persisted_cache] == 'write'
         value = yield
         PersistedCache::KeyValuePair.where(key: name).first.try(:destroy)
         PersistedCache::KeyValuePair.create!(key: name, value: value)
         Rails.cache.delete(name, options)
         return value
       end
-      if options[:use_persisted]
+      if %w{read require}.include?(options[:persisted_cache])
         if persisted_value = PersistedCache::KeyValuePair.where(key: name).first.try(:value)
           Rails.cache.write(name, persisted_value, options)
           return persisted_value
         else
-          if options[:fail_on_cache_miss]
+          if options[:persisted_cache] == 'require'
             raise PersistedCache::MissingRequiredCache.new("Required cached object does not exist in cache.")
           end
         end
@@ -45,7 +47,7 @@ module PersistedCache
     end
 
     def delete(name, options = nil)
-      if options && options[:delete_persisted]
+      if options && options[:persisted_cache] == 'delete'
         PersistedCache::KeyValuePair.where(key: name).first.try(:destroy)
       end
       super

--- a/lib/persisted_cache.rb
+++ b/lib/persisted_cache.rb
@@ -2,7 +2,6 @@ require 'extension'
 module PersistedCache
 
   class MissingRequiredCache < Exception; end
-  class InvalidOptions < Exception; end
   class << self
     attr_accessor :configuration
   end

--- a/lib/persisted_cache/version.rb
+++ b/lib/persisted_cache/version.rb
@@ -1,3 +1,3 @@
 module PersistedCache
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/dummy/app/models/some_model.rb
+++ b/spec/dummy/app/models/some_model.rb
@@ -1,7 +1,0 @@
-class SomeModel
-  def cached_method(options={})
-    Rails.cache.fetch('some_model_cached_method_key', options) do
-      (1..50).map{|i| i}
-    end
-  end
-end

--- a/spec/dummy/app/models/some_model.rb
+++ b/spec/dummy/app/models/some_model.rb
@@ -1,6 +1,6 @@
 class SomeModel
   def cached_method(options={})
-    Rails.cache.fetch('some_model_cached_method', options) do
+    Rails.cache.fetch('some_model_cached_method_key', options) do
       (1..50).map{|i| i}
     end
   end

--- a/spec/persisted_cache/opt_in_spec.rb
+++ b/spec/persisted_cache/opt_in_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe 'use_persisted option' do
+describe 'opt in' do
   include_context 'persisted_cache'
   context "when true" do
-    let(:options){{use_persisted: true}}
+    let(:options){{persisted_cache: 'read'}}
     let(:db_result){PersistedCache::KeyValuePair.new(key: key, value: SomeModel.method_results)}
     subject{SomeModel.new.cached_method(options)}
     it "should hit the db" do

--- a/spec/persisted_cache/persisted_cache_context.rb
+++ b/spec/persisted_cache/persisted_cache_context.rb
@@ -1,3 +1,14 @@
+class SomeModel
+  def self.method_results
+    (1..50).map{|i| i}
+  end
+  def cached_method(options={})
+    Rails.cache.fetch('some_model_cached_method_key', options) do
+      SomeModel.method_results
+    end
+  end
+end
+
 shared_context 'persisted_cache' do
   let(:key){'some_model_cached_method_key'}
   before do

--- a/spec/persisted_cache/persisted_cache_context.rb
+++ b/spec/persisted_cache/persisted_cache_context.rb
@@ -1,5 +1,5 @@
 shared_context 'persisted_cache' do
-  let(:key){'some_model_cached_method'}
+  let(:key){'some_model_cached_method_key'}
   before do
     PersistedCache::KeyValuePair.destroy_all
     Rails.cache.clear

--- a/spec/persisted_cache/use_persisted_option_spec.rb
+++ b/spec/persisted_cache/use_persisted_option_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'use_persisted option' do
+  include_context 'persisted_cache'
+  context "when true" do
+    let(:options){{use_persisted: true}}
+    let(:db_result){PersistedCache::KeyValuePair.new(key: key, value: SomeModel.method_results)}
+    subject{SomeModel.new.cached_method(options)}
+    it "should hit the db" do
+      expect(PersistedCache::KeyValuePair).to receive(:where).and_return([db_result])
+      expect(subject).to eql(SomeModel.method_results)
+      expect(Rails.cache.read(key)).to eql(SomeModel.method_results)
+    end
+  end
+  context "when not true" do
+    let(:options){{}}
+    subject{SomeModel.new.cached_method(options)}
+    it "should not hit the db" do
+      expect(PersistedCache::KeyValuePair).to receive(:where).never
+      expect(subject).to eql(SomeModel.method_results)
+      expect(Rails.cache.read(key)).to eql(SomeModel.method_results)
+    end
+  end
+end

--- a/spec/persisted_cache/with_block_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_kvp_exists_spec.rb
@@ -4,7 +4,7 @@ describe 'PersistedCacheTest' do
   include_context 'persisted_cache'
   context "when a block is passed" do
     subject{SomeModel.new.cached_method(options)}
-    let(:options){{}}
+    let(:options){{use_persisted: true}}
     context "persisted key value pair exists" do
       let(:persisted_value){[1,2,3,4,5]}
       let!(:existing_kvp){PersistedCache::KeyValuePair.create!(key: key, value: persisted_value)}
@@ -33,7 +33,7 @@ describe 'PersistedCacheTest' do
           end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{fail_on_cache_miss: true}}
+          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
           it "does not raise an error" do
             expect{subject}.not_to raise_error
           end
@@ -65,7 +65,7 @@ describe 'PersistedCacheTest' do
           end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{fail_on_cache_miss: true}}
+          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
           it "does not raise an error" do
             expect{subject}.not_to raise_error
           end

--- a/spec/persisted_cache/with_block_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_kvp_exists_spec.rb
@@ -11,14 +11,14 @@ describe 'PersistedCacheTest' do
       context "cache miss" do
         it "returns and caches value from db" do
           expect(subject.size).to eql(persisted_value.size)
-          expect(Rails.cache.fetch(key).size).to eql(persisted_value.size)
+          expect(Rails.cache.read(key).size).to eql(persisted_value.size)
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
           it "saves to the db, sets the cache and returns value" do
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(0)
             expect(subject.size).to eql(50)
-            expect(Rails.cache.fetch(key).size).to eql(50)
+            expect(Rails.cache.read(key).size).to eql(50)
           end
           context "fail_on_cache_miss option passed in" do
             let(:options){{persist: true, fail_on_cache_miss: true}}
@@ -55,16 +55,16 @@ describe 'PersistedCacheTest' do
         let(:value){[1]}
         before{manually_set_cache_value}
         it "returns value from cache" do
-          expect(Rails.cache.fetch(key)).to eql(value)
+          expect(Rails.cache.read(key)).to eql(value)
           expect(subject.size).to eql(1)
-          expect(Rails.cache.fetch(key).size).to eql(1)
+          expect(Rails.cache.read(key).size).to eql(1)
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
           it "saves to the db, sets the cache and returns value" do
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(0)
             expect(subject.size).to eql(50)
-            expect(Rails.cache.fetch(key).size).to eql(50)
+            expect(Rails.cache.read(key).size).to eql(50)
           end
           context "fail_on_cache_miss option passed in" do
             let(:options){{persist: true, fail_on_cache_miss: true}}

--- a/spec/persisted_cache/with_block_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_kvp_exists_spec.rb
@@ -4,7 +4,7 @@ describe 'PersistedCacheTest' do
   include_context 'persisted_cache'
   context "when a block is passed" do
     subject{SomeModel.new.cached_method(options)}
-    let(:options){{use_persisted: true}}
+    let(:options){{persisted_cache: 'read'}}
     context "persisted key value pair exists" do
       let(:persisted_value){[1,2,3,4,5]}
       let!(:existing_kvp){PersistedCache::KeyValuePair.create!(key: key, value: persisted_value)}
@@ -15,9 +15,8 @@ describe 'PersistedCacheTest' do
           expect(subject).to eql(persisted_value)
         end
         context "persist option passed in" do
-          let(:options){{persist: true}}
+          let(:options){{persisted_cache: 'write'}}
           it "updates db, does not set the rails cache and returns value" do
-            expect(Rails.cache.read(key)).to eql(persisted_value)
             expect(PersistedCache::KeyValuePair.find_by_key(key).id).to eql(existing_kvp.id)
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(0)
             expect(PersistedCache::KeyValuePair.find_by_key(key).id).not_to eql(existing_kvp.id)
@@ -25,15 +24,9 @@ describe 'PersistedCacheTest' do
             PersistedCache::KeyValuePair.destroy_all
             expect(Rails.cache.read(key)).to be_nil
           end
-          context "fail_on_cache_miss option passed in" do
-            let(:options){{persist: true, fail_on_cache_miss: true}}
-            it "raises an error" do
-              expect{subject}.to raise_error(PersistedCache::InvalidOptions)
-            end
-          end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
+          let(:options){{persisted_cache: 'require'}}
           it "does not raise an error" do
             expect{subject}.not_to raise_error
           end
@@ -47,7 +40,7 @@ describe 'PersistedCacheTest' do
           expect(subject).to eql(value)
         end
         context "persist option passed in" do
-          let(:options){{persist: true}}
+          let(:options){{persisted_cache: 'write'}}
           it "updates db, deletes the key from the rails cache and returns value" do
             expect(Rails.cache.read(key)).to eql(value)
             expect(PersistedCache::KeyValuePair.find_by_key(key).id).to eql(existing_kvp.id)
@@ -57,15 +50,9 @@ describe 'PersistedCacheTest' do
             PersistedCache::KeyValuePair.destroy_all
             expect(Rails.cache.read(key)).to be_nil
           end
-          context "fail_on_cache_miss option passed in" do
-            let(:options){{persist: true, fail_on_cache_miss: true}}
-            it "raises an error" do
-              expect{subject}.to raise_error(PersistedCache::InvalidOptions)
-            end
-          end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
+          let(:options){{persisted_cache: 'require'}}
           it "does not raise an error" do
             expect{subject}.not_to raise_error
           end

--- a/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
@@ -4,7 +4,7 @@ describe 'PersistedCacheTest' do
   include_context 'persisted_cache'
   context "when a block is passed" do
     subject{SomeModel.new.cached_method(options)}
-    let(:options){{}}
+    let(:options){{use_persisted: true}}
     context "no persisted key value pair exists" do
       context "cache miss" do
         it "sets rails cache from db and returns value" do
@@ -28,7 +28,7 @@ describe 'PersistedCacheTest' do
           end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{fail_on_cache_miss: true}}
+          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
           it "raises an error" do
             expect{subject}.to raise_error(PersistedCache::MissingRequiredCache)
           end
@@ -56,7 +56,7 @@ describe 'PersistedCacheTest' do
           end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{fail_on_cache_miss: true}}
+          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
           it "does not raise an error" do
             expect{subject}.not_to raise_error
           end

--- a/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
@@ -9,14 +9,14 @@ describe 'PersistedCacheTest' do
       context "cache miss" do
         it "returns and caches value returned by method" do
           expect(subject.size).to eql(50)
-          expect(Rails.cache.fetch(key).size).to eql(50)
+          expect(Rails.cache.read(key).size).to eql(50)
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
           it "saves to the db, sets the cache and returns value" do
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
             expect(subject.size).to eql(50)
-            expect(Rails.cache.fetch(key).size).to eql(50)
+            expect(Rails.cache.read(key).size).to eql(50)
           end
           context "fail_on_cache_miss option passed in" do
             let(:options){{persist: true, fail_on_cache_miss: true}}
@@ -53,16 +53,16 @@ describe 'PersistedCacheTest' do
         let(:value){[1]}
         before{manually_set_cache_value}
         it "returns value from cache" do
-          expect(Rails.cache.fetch(key)).to eql(value)
+          expect(Rails.cache.read(key)).to eql(value)
           expect(subject.size).to eql(1)
-          expect(Rails.cache.fetch(key).size).to eql(1)
+          expect(Rails.cache.read(key).size).to eql(1)
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
           it "saves to the db, sets the cache and returns value" do
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
             expect(subject.size).to eql(50)
-            expect(Rails.cache.fetch(key).size).to eql(50)
+            expect(Rails.cache.read(key).size).to eql(50)
           end
           context "fail_on_cache_miss option passed in" do
             let(:options){{persist: true, fail_on_cache_miss: true}}

--- a/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
@@ -13,10 +13,11 @@ describe 'PersistedCacheTest' do
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
-          it "saves to the db, sets the cache and returns value" do
+          it "saves to the db, does not set the rails cache and returns value" do
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
             expect(subject.size).to eql(50)
-            expect(Rails.cache.read(key).size).to eql(50)
+            PersistedCache::KeyValuePair.destroy_all
+            expect(Rails.cache.read(key)).to be_nil
           end
           context "fail_on_cache_miss option passed in" do
             let(:options){{persist: true, fail_on_cache_miss: true}}
@@ -24,28 +25,11 @@ describe 'PersistedCacheTest' do
               expect{subject}.to raise_error(PersistedCache::InvalidOptions)
             end
           end
-          context "with other options passed in" do
-            let(:options){{persist: true, foo: :bar}}
-            it "respects the other options" do
-              expect(Rails.cache).to receive(:write).with(key, (1..50).map{|i| i}, {:persist=>true, :foo=>:bar, :force=>true})
-              subject
-            end
-          end
         end
         context "fail_on_cache_miss option passed in" do
           let(:options){{fail_on_cache_miss: true}}
           it "raises an error" do
             expect{subject}.to raise_error(PersistedCache::MissingRequiredCache)
-          end
-        end
-        context "skip_rails_cache option passed in" do
-          let(:options){{persist: true, skip_rails_cache: true}}
-          it "saves to the db, sets the cache and returns value" do
-            Rails.cache.write(key, [1,2,3])
-            expect(Rails.cache.read(key).size).to eql(3)
-            expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
-            expect(subject.size).to eql(50)
-            expect(Rails.cache.read(key).size).to eql(50)
           end
         end
       end
@@ -59,25 +43,16 @@ describe 'PersistedCacheTest' do
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
-          it "saves to the db, sets the cache and returns value" do
+          it "saves to the db, does not set the rails cache and returns value" do
             expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
             expect(subject.size).to eql(50)
-            expect(Rails.cache.read(key).size).to eql(50)
+            PersistedCache::KeyValuePair.destroy_all
+            expect(Rails.cache.read(key)).to be_nil
           end
           context "fail_on_cache_miss option passed in" do
             let(:options){{persist: true, fail_on_cache_miss: true}}
             it "raises an error" do
               expect{subject}.to raise_error(PersistedCache::InvalidOptions)
-            end
-          end
-          context "skip_rails_cache option passed in" do
-            let(:options){{persist: true, skip_rails_cache: true}}
-            it "saves to db, clears the cache and returns value" do
-              Rails.cache.write(key, [1,2,3])
-              expect(Rails.cache.read(key).size).to eql(3)
-              expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
-              expect(subject.size).to eql(50)
-              expect(Rails.cache.read(key).size).to eql(50)
             end
           end
         end

--- a/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
@@ -7,16 +7,17 @@ describe 'PersistedCacheTest' do
     let(:options){{}}
     context "no persisted key value pair exists" do
       context "cache miss" do
-        it "returns and caches value returned by method" do
-          expect(subject.size).to eql(50)
-          expect(Rails.cache.read(key).size).to eql(50)
+        it "sets rails cache from db and returns value" do
+          expect(Rails.cache.read(key)).to be_nil
+          expect(PersistedCache::KeyValuePair).to receive(:create!).never
+          expect(subject).to eql(SomeModel.method_results)
+          expect(Rails.cache.read(key)).to eql(SomeModel.method_results)
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
           it "saves to the db, does not set the rails cache and returns value" do
-            expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
-            expect(subject.size).to eql(50)
-            PersistedCache::KeyValuePair.destroy_all
+            expect(PersistedCache::KeyValuePair).to receive(:create!)
+            expect(subject).to eql(SomeModel.method_results)
             expect(Rails.cache.read(key)).to be_nil
           end
           context "fail_on_cache_miss option passed in" do
@@ -37,16 +38,14 @@ describe 'PersistedCacheTest' do
         let(:value){[1]}
         before{manually_set_cache_value}
         it "returns value from cache" do
-          expect(Rails.cache.read(key)).to eql(value)
-          expect(subject.size).to eql(1)
-          expect(Rails.cache.read(key).size).to eql(1)
+          expect(PersistedCache::KeyValuePair).to receive(:where).never
+          expect(subject).to eql(value)
         end
         context "persist option passed in" do
           let(:options){{persist: true}}
           it "saves to the db, does not set the rails cache and returns value" do
-            expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(1)
-            expect(subject.size).to eql(50)
-            PersistedCache::KeyValuePair.destroy_all
+            expect(PersistedCache::KeyValuePair).to receive(:create!)
+            expect(subject).to eql(SomeModel.method_results)
             expect(Rails.cache.read(key)).to be_nil
           end
           context "fail_on_cache_miss option passed in" do

--- a/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
+++ b/spec/persisted_cache/with_block_no_kvp_exists_spec.rb
@@ -4,7 +4,7 @@ describe 'PersistedCacheTest' do
   include_context 'persisted_cache'
   context "when a block is passed" do
     subject{SomeModel.new.cached_method(options)}
-    let(:options){{use_persisted: true}}
+    let(:options){{persisted_cache: 'read'}}
     context "no persisted key value pair exists" do
       context "cache miss" do
         it "sets rails cache from db and returns value" do
@@ -14,21 +14,15 @@ describe 'PersistedCacheTest' do
           expect(Rails.cache.read(key)).to eql(SomeModel.method_results)
         end
         context "persist option passed in" do
-          let(:options){{persist: true}}
+          let(:options){{persisted_cache: 'write'}}
           it "saves to the db, does not set the rails cache and returns value" do
             expect(PersistedCache::KeyValuePair).to receive(:create!)
             expect(subject).to eql(SomeModel.method_results)
             expect(Rails.cache.read(key)).to be_nil
           end
-          context "fail_on_cache_miss option passed in" do
-            let(:options){{persist: true, fail_on_cache_miss: true}}
-            it "raises an error" do
-              expect{subject}.to raise_error(PersistedCache::InvalidOptions)
-            end
-          end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
+          let(:options){{persisted_cache: 'require'}}
           it "raises an error" do
             expect{subject}.to raise_error(PersistedCache::MissingRequiredCache)
           end
@@ -42,21 +36,15 @@ describe 'PersistedCacheTest' do
           expect(subject).to eql(value)
         end
         context "persist option passed in" do
-          let(:options){{persist: true}}
+          let(:options){{persisted_cache: 'write'}}
           it "saves to the db, does not set the rails cache and returns value" do
             expect(PersistedCache::KeyValuePair).to receive(:create!)
             expect(subject).to eql(SomeModel.method_results)
             expect(Rails.cache.read(key)).to be_nil
           end
-          context "fail_on_cache_miss option passed in" do
-            let(:options){{persist: true, fail_on_cache_miss: true}}
-            it "raises an error" do
-              expect{subject}.to raise_error(PersistedCache::InvalidOptions)
-            end
-          end
         end
         context "fail_on_cache_miss option passed in" do
-          let(:options){{use_persisted: true, fail_on_cache_miss: true}}
+          let(:options){{persisted_cache: 'require'}}
           it "does not raise an error" do
             expect{subject}.not_to raise_error
           end

--- a/spec/persisted_cache/without_block_spec.rb
+++ b/spec/persisted_cache/without_block_spec.rb
@@ -22,11 +22,11 @@ describe 'PersistedCacheTest' do
     let(:value){[41,2,33,14,95]}
     before do
       expect{Rails.cache.fetch(key_to_delete, persist: true){value}}.to change(PersistedCache::KeyValuePair, :count).by(1)
-      expect(Rails.cache.fetch(key_to_delete)).to eql(value)
+      expect(Rails.cache.read(key_to_delete)).to eql(value)
     end
     subject{Rails.cache.delete(key_to_delete, delete_persisted: true)}
     it "should remove the pair from cache and db" do
-      expect(Rails.cache.fetch('key_to_delete')).to be_nil
+      expect(Rails.cache.read('key_to_delete')).to be_nil
       expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(-1)
     end
   end
@@ -37,7 +37,7 @@ describe 'PersistedCacheTest' do
     it "should not be affected" do
       subject
       sleep 2
-      expect(Rails.cache.fetch(key)).to be_nil
+      expect(Rails.cache.read(key)).to be_nil
     end
   end
 

--- a/spec/persisted_cache/without_block_spec.rb
+++ b/spec/persisted_cache/without_block_spec.rb
@@ -8,6 +8,21 @@ describe 'PersistedCacheTest' do
       it "should return false" do
         expect(subject).to be_falsey
       end
+      context "required option is passed" do
+        subject{Rails.cache.fetch(key, persisted_cache: 'require')}
+        let(:value){{foo: 'bar'}}
+        context "kvp exists" do
+          before{expect{Rails.cache.fetch(key, persisted_cache: 'write'){value}}.to change(PersistedCache::KeyValuePair, :count).by(1)}
+          it "should raise no error" do
+            expect{subject}.not_to raise_error
+          end
+        end
+        context "kvp doesn't exist" do
+          it "should raise error" do
+            expect{subject}.to raise_error(PersistedCache::MissingRequiredCache)
+          end
+        end
+      end
     end
     context "cache hit" do
       let(:value){'blafoo'}
@@ -21,12 +36,12 @@ describe 'PersistedCacheTest' do
     let(:key_to_delete){'delete-me'}
     let(:value){[41,2,33,14,95]}
     before do
-      expect{Rails.cache.fetch(key_to_delete, persist: true){value}}.to change(PersistedCache::KeyValuePair, :count).by(1)
-      expect(Rails.cache.read(key_to_delete)).to eql(value)
+      expect{Rails.cache.fetch(key_to_delete, persisted_cache: 'write'){value}}.to change(PersistedCache::KeyValuePair, :count).by(1)
+      expect(Rails.cache.fetch(key_to_delete, persisted_cache: 'read')).to eql(value)
     end
-    subject{Rails.cache.delete(key_to_delete, delete_persisted: true)}
+    subject{Rails.cache.delete(key_to_delete, persisted_cache: 'delete')}
     it "should remove the pair from cache and db" do
-      expect(Rails.cache.read('key_to_delete')).to be_nil
+      expect(Rails.cache.read('key_to_delete', persisted_cache: 'read')).to be_nil
       expect{subject}.to change(PersistedCache::KeyValuePair, :count).by(-1)
     end
   end


### PR DESCRIPTION
Hey Guys,

This makes persisted cache opt in. If you want to fall back to the db for cache values on cache miss, pass persisted_cache: 'read' to Rails.cache.fetch or Rails.cache.read. To persist values to the db, pass the persisted_cache: 'write' option. To delete, use persisted_cache: 'delete'. Was able to remove a couple of options and keep the expected behavior.

Hope all is well,
Bernd
